### PR TITLE
Determining access to the Bitrix database without php

### DIFF
--- a/helper/functions.go
+++ b/helper/functions.go
@@ -135,3 +135,14 @@ func isComposePlugin() bool {
 
 	return true
 }
+
+// CleanSlice delete an empty value in a slice
+func CleanSlice(s []string) []string {
+	var r []string
+	for _, str := range s {
+		if str != "" {
+			r = append(r, str)
+		}
+	}
+	return r
+}


### PR DESCRIPTION
Determining access to the Bitrix database if PHP is not installed on the server in the host system

Refs: DL-T-42